### PR TITLE
[HAC 1157]: Init the hac-build-service repo with OWNERS and placeholder scripts

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,21 @@
+reviewers:
+  - abhinandan13jan
+  - christianvogt
+  - debsmita1
+  - divyanshiGupta
+  - invincibleJai
+  - jerolimov
+  - jrichter1
+  - karthikjeeyar
+  - nemesis09
+  - rohitkrai03
+  - rottencandy
+  - sahil143
+  - sawood14012
+  - vikram-raj
+approvers:
+  - christianvogt
+  - invincibleJai
+  - jerolimov
+  - rohitkrai03
+component: HAC Build Service

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+print_error() { printf "%s\n" "$*" >&2; }
+
+printf "Build some stuff!"

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+print_error() { printf "%s\n" "$*" >&2; }
+
+printf "Write some tests!"


### PR DESCRIPTION
Basic config required to setup PROW

See https://issues.redhat.com/browse/HAC-1157