### PR TITLE
Fix React hook errors pulling build service into hac-core

### DIFF
--- a/config/remotePlugin.js
+++ b/config/remotePlugin.js
@@ -47,6 +47,7 @@ module.exports = {
     '@openshift/dynamic-plugin-sdk': { singleton: true, import: false },
     '@openshift/dynamic-plugin-sdk-utils': { singleton: true, import: false },
     'react-router-dom': { singleton: true },
+    react: { singleton: true, import: false },
     '@scalprum/react-core': { singleton: true, import: false },
     '@patternfly/quickstarts': { singleton: true, eager: true },
   },

--- a/src/PluginEntry/PluginEntry.scss
+++ b/src/PluginEntry/PluginEntry.scss
@@ -1,3 +1,4 @@
-div > h1 {
-  display: block;
+.page-header {
+  text-align: center;
+  padding-top: 40px;
 }

--- a/src/PluginEntry/PluginEntry.tsx
+++ b/src/PluginEntry/PluginEntry.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { Title } from '@patternfly/react-core';
 import { NotFound } from '../NotFound';
+import './PluginEntry.scss';
 
 const PluginEntry = () => {
   return (
     <div>
-      <Title headingLevel="h1" data-testid="page-header">
+      <Title className="page-header" headingLevel="h1" data-testid="page-header">
         Welcome to HAC-Build Service!
       </Title>
       <NotFound />


### PR DESCRIPTION
Fixes react hook error deploying hac-build-service to hac-core:

## BEFORE
![image](https://user-images.githubusercontent.com/21317056/172219571-cba95611-6106-44f6-884d-719d6a6bc95b.png)


## AFTER
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/21317056/172219535-f3cba1c2-211d-4ca7-b968-3ea10cc3b0e5.png">
